### PR TITLE
The informational message give wrong key to add for debug_local_domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ composer require bolt/configuration-notices
 You can influence a few of the checks through the configuration. How meta!
 
 ```yaml
+debug_local_domains: [ '.localhost' ]
+
 configuration_notices:
-    local_domains: [ '.localhost' ]
     log_threshold: 1000
 ```
 

--- a/src/EventListener/ConfigurationNoticesListener.php
+++ b/src/EventListener/ConfigurationNoticesListener.php
@@ -131,7 +131,7 @@ class ConfigurationNoticesListener implements EventSubscriberInterface
             return;
         }
 
-        $domainPartials = (array) $this->app['config']->get('general/configuration_notices/local_domains', []);
+        $domainPartials = (array) $this->app['config']->get('general/debug_local_domains', []);
 
         $domainPartials = array_unique(array_merge(
             (array) $domainPartials,


### PR DESCRIPTION
The informational message you see when viewing the site on a non debug domain with debug turned on mentions the configuration key `debug_local_domains` .. but it does not read that key.

See : https://github.com/bolt/configuration-notices/blob/master/src/EventListener/ConfigurationNoticesListener.php#L147-L151
```
"If you wish to hide this message, add a key to your <code>config.yml</code> with a (partial) domain name in it, that should be seen as a development environment: <code>debug_local_domains: [ '.foo' ]</code>.",
```

You would actually have to create the following key `general/configuration_notices/local_domains` for it to work https://github.com/bolt/configuration-notices/blob/master/src/EventListener/ConfigurationNoticesListener.php#L134 as was mentioned in the readme.

This PR changes that and makes the check look for the mentioned key.

 You could also turn it around and make the message tell you about the `general/configuration_notices/local_domains` key.
